### PR TITLE
Force wiki page string into urldecoder to ensure correct urlBuilder result

### DIFF
--- a/src/main/java/net/runelite/data/dump/MediaWiki.java
+++ b/src/main/java/net/runelite/data/dump/MediaWiki.java
@@ -95,9 +95,12 @@ public class MediaWiki
 	{
 		// decode html encoded page name
 		// ex: Mage%27s book -> Mage's_book
-		try {
+		try
+		{
 			page = URLDecoder.decode(page, StandardCharsets.UTF_8.name());
-		} catch (UnsupportedEncodingException e) {
+		}
+		catch (UnsupportedEncodingException e)
+		{
 			// do nothing, keep page the same
 		}
 

--- a/src/main/java/net/runelite/data/dump/MediaWiki.java
+++ b/src/main/java/net/runelite/data/dump/MediaWiki.java
@@ -24,6 +24,7 @@
 package net.runelite.data.dump;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Map;
@@ -32,6 +33,8 @@ import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 public class MediaWiki
 {
@@ -88,8 +91,16 @@ public class MediaWiki
 		return "";
 	}
 
-	public String getPageData(final String page, int section)
+	public String getPageData(String page, int section)
 	{
+		// decode html encoded page name
+		// ex: Mage%27s book -> Mage's_book
+		try {
+			page = URLDecoder.decode(page, StandardCharsets.UTF_8.name());
+		} catch (UnsupportedEncodingException e) {
+			// do nothing, keep page the same
+		}
+
 		final HttpUrl.Builder urlBuilder = base.newBuilder()
 			.addPathSegment("api.php")
 			.addQueryParameter("action", "parse")


### PR DESCRIPTION
MediaWiki's getPageData function sometimes takes in a page already urlencoded.

This PR just decodes the urlencoded page so the following urlBuilder can function properly.

For easy unit testing:
- comment out line 53 in App.java
- after line 104 in ItemStatsDumper.java, add this line of code to only search for Mage's book and Tome of Fire:
`if (!(item.id == 6889 || item.id == 20714)) { return; }`
- item_stats.json in \runelite\runelite-client\src\main\resources\item_stats.json should look like this:


{
  "6889": {
    "equipable": true,
    "weight": 1.0,
    "equipment": {
      "slot": 5,
      "amagic": 15,
      "dmagic": 15
    }
  },
  "20714": {
    "equipable": true,
    "weight": 1.0,
    "equipment": {
      "slot": 5,
      "amagic": 8,
      "dmagic": 8
    }
  }
}

Closes https://github.com/runelite/runelite/issues/8157