### PR TITLE
add switch infobox item parsing support

### DIFF
--- a/src/main/java/net/runelite/data/dump/MediaWikiTemplate.java
+++ b/src/main/java/net/runelite/data/dump/MediaWikiTemplate.java
@@ -27,6 +27,7 @@ import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -188,6 +189,34 @@ public class MediaWikiTemplate
 		}
 
 		return new MediaWikiTemplate(out);
+	}
+
+	/**
+	 * Looks for and parses the `Switch infobox` into a {@link MediaWikiTemplate} and then iterates over the `item#` values.
+	 * Attempts to parse each `item#` value via `parseWikiText`, matching the `name` attribute. null values are ignored
+	 *
+	 * @param name only parses MediaWikiTemplates from `Switch infobox` if matches this value. (case insensitive)
+	 * @param baseTemplate the {@link MediaWikiTemplate} representation of the `Switch infobox` to parse from
+	 * @return List of all valid {@link MediaWikiTemplate}s matching `name` from `baseTemplate`s `item#` values
+	 */
+	public static List<MediaWikiTemplate> parseSwitchInfoboxItems(final String name, final MediaWikiTemplate baseTemplate)
+	{
+		final List<MediaWikiTemplate> templates = new ArrayList<>();
+
+		String value;
+		int suffix = 1;
+		while ((value = baseTemplate.getValue("item" + suffix)) != null)
+		{
+			final MediaWikiTemplate subTemplate = parseWikitext(name, value);
+			if (subTemplate != null)
+			{
+				templates.add(subTemplate);
+			}
+
+			suffix++;
+		}
+
+		return templates;
 	}
 
 	private final Map<String, String> map;

--- a/src/test/java/net/runelite/data/dump/MediaWikiTemplateTest.java
+++ b/src/test/java/net/runelite/data/dump/MediaWikiTemplateTest.java
@@ -23,6 +23,7 @@
  */
 package net.runelite.data.dump;
 
+import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.jupiter.api.Test;
@@ -420,5 +421,80 @@ class MediaWikiTemplateTest
 		final MediaWikiTemplate exchangeInfo = MediaWikiTemplate.parseLua(exchangeInfoData);
 		assertNotNull(exchangeInfo);
 		assertEquals((int) exchangeInfo.getInt("value"), -205000);
+	}
+
+	@Test
+	void parseSwitchInfobox()
+	{
+		final String data =
+			"{{External|rs}}\n" +
+				"{{Switch infobox\n" +
+				"|item1= \n" +
+				"{{Infobox Monster\n" +
+					"|name = Ghast\n" +
+					"|combat = 30\n" +
+					"|id = 946\n" +
+				"}}\n" +
+				"|text1 = Level 30\n" +
+				"|item2= \n" +
+				"{{Infobox Monster\n" +
+					"|name = Ghast\n" +
+					"|combat = 79\n" +
+					"|id = 5625\n" +
+				"}}\n" +
+				"|text2 = Level 79\n" +
+				"|item3= \n" +
+				"{{Infobox Monster\n" +
+					"|name = Ghast\n" +
+					"|combat = 109\n" +
+					"|id = 5626\n" +
+				"}}\n" +
+				"|text3 = Level 109\n" +
+				"|item4= \n" +
+				"{{Infobox Monster\n" +
+					"|name = Ghast\n" +
+					"|combat = 139\n" +
+					"|id = 5627\n" +
+				"}}\n" +
+				"|text4 = Level 139\n" +
+				"|item5 =\n" +
+				"{{Infobox non-player character\n" +
+					"|name = \n" +
+					"|update = Nature Spirit Quest\n" +
+					"|race = Undead\n" +
+					"|members = Yes\n" +
+					"|quest = [[Nature Spirit]]\n" +
+					"|location = [[Morytania]]\n" +
+					"|shop = No\n" +
+					"|gender = N/A\n" +
+					"|examine = \n" +
+					"|id = 945, 5622, 5623, 5624\n" +
+				"}}\n" +
+				"|text5 = Invisible\n" +
+				"}}";
+
+		final MediaWikiTemplate switchInfobox = MediaWikiTemplate.parseWikitext("Switch infobox", data);
+		assertNotNull(switchInfobox);
+
+		// Infobox monster
+		final List<MediaWikiTemplate> templates = MediaWikiTemplate.parseSwitchInfoboxItems("Infobox monster", switchInfobox);
+		assertEquals(templates.size(), 4);
+
+		final MediaWikiTemplate item1 = templates.get(0);
+		assertEquals(item1.getInt("combat"), 30);
+
+		final MediaWikiTemplate item2 = templates.get(1);
+		assertEquals(item2.getInt("combat"), 79);
+
+		// Infobox non-player character
+		final List<MediaWikiTemplate> npcs = MediaWikiTemplate.parseSwitchInfoboxItems("Infobox non-player character", switchInfobox);
+		assertEquals(npcs.size(), 1);
+
+		final MediaWikiTemplate npc1 = npcs.get(0);
+		assertEquals(npc1.getValue("race"), "Undead");
+
+		// Infobox item
+		final List<MediaWikiTemplate> items = MediaWikiTemplate.parseSwitchInfoboxItems("Infobox item", switchInfobox);
+		assertEquals(items.size(), 0);
 	}
 }


### PR DESCRIPTION
Adds a method to parse the `item#` values from the `Switch infobox` MediaWikiTemplate. Thought this was better as a stand alone PR as its not directly related to npcs.